### PR TITLE
Separate PHP versions

### DIFF
--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -1,0 +1,17 @@
+FROM thedrum/php:5.3-apache
+
+MAINTAINER Chris Shennan <chris@chrisshennan.com>
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN curl https://phar.phpunit.de/phpunit-4.8.36.phar -L > phpunit.phar \
+  && chmod +x phpunit.phar \
+  && mv phpunit.phar /usr/local/bin/phpunit \
+  && phpunit --version
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]

--- a/5.3/dev/Dockerfile
+++ b/5.3/dev/Dockerfile
@@ -1,0 +1,17 @@
+FROM thedrum/php:5.3-apache-dev
+
+MAINTAINER Chris Shennan <chris@chrisshennan.com>
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN curl https://phar.phpunit.de/phpunit-4.8.36.phar -L > phpunit.phar \
+  && chmod +x phpunit.phar \
+  && mv phpunit.phar /usr/local/bin/phpunit \
+  && phpunit --version
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -1,0 +1,17 @@
+FROM thedrum/php:5.5-apache
+
+MAINTAINER Chris Shennan <chris@chrisshennan.com>
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN curl https://phar.phpunit.de/phpunit-4.8.36.phar -L > phpunit.phar \
+  && chmod +x phpunit.phar \
+  && mv phpunit.phar /usr/local/bin/phpunit \
+  && phpunit --version
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]

--- a/5.5/dev/Dockerfile
+++ b/5.5/dev/Dockerfile
@@ -1,0 +1,17 @@
+FROM thedrum/php:5.5-apache-dev
+
+MAINTAINER Chris Shennan <chris@chrisshennan.com>
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN curl https://phar.phpunit.de/phpunit-4.8.36.phar -L > phpunit.phar \
+  && chmod +x phpunit.phar \
+  && mv phpunit.phar /usr/local/bin/phpunit \
+  && phpunit --version
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,0 +1,17 @@
+FROM thedrum/php:5.6-fpm
+
+MAINTAINER Chris Shennan <chris@chrisshennan.com>
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN curl https://phar.phpunit.de/phpunit-5.7.9.phar -L > phpunit.phar \
+  && chmod +x phpunit.phar \
+  && mv phpunit.phar /usr/local/bin/phpunit \
+  && phpunit --version
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]

--- a/5.6/dev/Dockerfile
+++ b/5.6/dev/Dockerfile
@@ -1,0 +1,17 @@
+FROM thedrum/php:5.6-fpm-dev
+
+MAINTAINER Chris Shennan <chris@chrisshennan.com>
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN curl https://phar.phpunit.de/phpunit-5.7.9.phar -L > phpunit.phar \
+  && chmod +x phpunit.phar \
+  && mv phpunit.phar /usr/local/bin/phpunit \
+  && phpunit --version
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,0 +1,17 @@
+FROM thedrum/php:7.0-fpm
+
+MAINTAINER Chris Shennan <chris@chrisshennan.com>
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN curl https://phar.phpunit.de/phpunit-6.5.7.phar -L > phpunit.phar \
+  && chmod +x phpunit.phar \
+  && mv phpunit.phar /usr/local/bin/phpunit \
+  && phpunit --version
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]

--- a/7.0/dev/Dockerfile
+++ b/7.0/dev/Dockerfile
@@ -1,0 +1,17 @@
+FROM thedrum/php:7.0-fpm-dev
+
+MAINTAINER Chris Shennan <chris@chrisshennan.com>
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN curl https://phar.phpunit.de/phpunit-6.5.7.phar -L > phpunit.phar \
+  && chmod +x phpunit.phar \
+  && mv phpunit.phar /usr/local/bin/phpunit \
+  && phpunit --version
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -1,10 +1,11 @@
-FROM thedrum/php:7-fpm-dev
+FROM thedrum/php:7.1-fpm
+
 MAINTAINER Chris Shennan <chris@chrisshennan.com>
 
 RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
  && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
 
-RUN curl https://phar.phpunit.de/phpunit-5.5.0.phar -L > phpunit.phar \
+RUN curl https://phar.phpunit.de/phpunit-7.0.2.phar -L > phpunit.phar \
   && chmod +x phpunit.phar \
   && mv phpunit.phar /usr/local/bin/phpunit \
   && phpunit --version

--- a/7.1/dev/Dockerfile
+++ b/7.1/dev/Dockerfile
@@ -1,0 +1,17 @@
+FROM thedrum/php:7.1-fpm-dev
+
+MAINTAINER Chris Shennan <chris@chrisshennan.com>
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN curl https://phar.phpunit.de/phpunit-7.0.2.phar -L > phpunit.phar \
+  && chmod +x phpunit.phar \
+  && mv phpunit.phar /usr/local/bin/phpunit \
+  && phpunit --version
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,0 +1,17 @@
+FROM thedrum/php:7.2-fpm
+
+MAINTAINER Chris Shennan <chris@chrisshennan.com>
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN curl https://phar.phpunit.de/phpunit-7.0.2.phar -L > phpunit.phar \
+  && chmod +x phpunit.phar \
+  && mv phpunit.phar /usr/local/bin/phpunit \
+  && phpunit --version
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]

--- a/7.2/dev/Dockerfile
+++ b/7.2/dev/Dockerfile
@@ -1,0 +1,17 @@
+FROM thedrum/php:7.2-fpm-dev
+
+MAINTAINER Chris Shennan <chris@chrisshennan.com>
+
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
+
+RUN curl https://phar.phpunit.de/phpunit-7.0.2.phar -L > phpunit.phar \
+  && chmod +x phpunit.phar \
+  && mv phpunit.phar /usr/local/bin/phpunit \
+  && phpunit --version
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/phpunit"]
+CMD ["--help"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,10 +1,11 @@
-FROM thedrum/php:7-fpm
+FROM thedrum/php:%%PHP_IMAGE%%
+
 MAINTAINER Chris Shennan <chris@chrisshennan.com>
 
 RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
  && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
 
-RUN curl https://phar.phpunit.de/phpunit-5.5.0.phar -L > phpunit.phar \
+RUN curl %%PHAR_LOCATION%% -L > phpunit.phar \
   && chmod +x phpunit.phar \
   && mv phpunit.phar /usr/local/bin/phpunit \
   && phpunit --version

--- a/README.md
+++ b/README.md
@@ -1,9 +1,39 @@
 # Supported tags and respective `Dockerfile` links
- - `0.1`, `latest` (*[0.1/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/0.1/Dockerfile)*)
- - `0.1-dev` (*[0.1/dev/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/0.1/dev/Dockerfile)*)
+ - `7.2`, `latest` (*[7.2/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/7.2/Dockerfile)*)
+ - `7.2-dev` (*[7.2/dev/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/7.2/dev/Dockerfile)*)
+ - `7.1` (*[7.1/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/7.1/Dockerfile)*)
+ - `7.1-dev` (*[7.1/dev/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/7.1/dev/Dockerfile)*)
+ - `5.6` (*[5.6/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/5.6/Dockerfile)*)
+ - `5.6-dev` (*[5.6/dev/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/5.6/dev/Dockerfile)*)
+ - `5.5` (*[5.5/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/5.5/Dockerfile)*)
+ - `5.5-dev` (*[5.5/dev/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/5.5/dev/Dockerfile)*)
+ - `5.3` (*[5.3/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/5.3/Dockerfile)*)
+ - `5.3-dev` (*[5.3/dev/Dockerfile](https://github.com/thedrum-developers/docker-phpunit/blob/master/5.3/dev/Dockerfile)*)
 
 # Usage
-```
-docker run -it --rm -v ${PWD}:/app thedrum/phpunit -c phpunit.xml.dist
 
+## Use latest image
+```bash
+docker run -it --rm -v ${PWD}:/app thedrum/phpunit -c phpunit.xml.dist
+```
+
+## Use specific image
+```bash
+docker run -it --rm -v ${PWD}:/app thedrum/phpunit:7.2 -c phpunit.xml.dist
+```
+
+## Use with Xdebug
+
+Specify the image you wish with the `-dev` variant which has Xdebug installed.
+
+The XDEBUG_CONFIG settings will attempt to connect to the Docker bridge network IP.
+
+The PHP_IDE_CONFIG will set the server name of the debug connection to `test.{current directory name}`, for example `test.my-api` which can be used by your IDE to set server
+and path mappings.
+
+```bash
+docker run -it --rm \
+    -e PHP_IDE_CONFIG=serverName=test.$(basename `pwd`) \
+    -e XDEBUG_CONFIG="remote_host=$(docker network inspect --format='{{(index (index .IPAM.Config) 0).Gateway}}' bridge) remote_enable=1" \
+    -v ${PWD}:/app thedrum/phpunit:7.2-dev -c phpunit.xml.dist
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Set the directory of this script
+BUILD_BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# List of PHP -> PHPUnit Versions
+declare -A IMAGE_MAP=(
+    ["5.3-apache"]="4.8.36"
+    ["5.5-apache"]="4.8.36"
+    ["5.6-fpm"]="5.7.9"
+    ["7.0-fpm"]="6.5.7"
+    ["7.1-fpm"]="7.0.2"
+    ["7.2-fpm"]="7.0.2"
+)
+
+for phpImage in "${!IMAGE_MAP[@]}"; do
+
+    # Strip the image type out of the version (-fpm / -apache)
+    phpVersion=$(echo $phpImage| cut -d'-' -f 1)
+
+    echo "Building Dockerfiles for PHP $phpVersion and PHP Unit ${IMAGE_MAP[$phpVersion]}...";
+
+    # Create directories if needed
+    if [ ! -d "$BUILD_BASE_DIR/$phpVersion" ]; then
+        mkdir -p "$BUILD_BASE_DIR/$phpVersion/dev";
+    fi
+
+    # Build regular image
+    cat "$BUILD_BASE_DIR/Dockerfile.template" > "$BUILD_BASE_DIR/$phpVersion/Dockerfile"
+
+    sed -ri \
+        -e 's!%%PHP_IMAGE%%!'"${phpImage}"'!' \
+        -e 's!%%PHAR_LOCATION%%!'"https://phar.phpunit.de/phpunit-${IMAGE_MAP[$phpImage]}.phar"'!' \
+        "$BUILD_BASE_DIR/$phpVersion/Dockerfile"
+
+    # Build dev variant
+    cat "$BUILD_BASE_DIR/Dockerfile.template" > "$BUILD_BASE_DIR/$phpVersion/dev/Dockerfile"
+
+    sed -ri \
+        -e 's!%%PHP_IMAGE%%!'"${phpImage}-dev"'!' \
+        -e 's!%%PHAR_LOCATION%%!'"https://phar.phpunit.de/phpunit-${IMAGE_MAP[$phpImage]}.phar"'!' \
+        "$BUILD_BASE_DIR/$phpVersion/dev/Dockerfile"
+
+done


### PR DESCRIPTION
I've added new images and their development / Xdebug variants for each version of PHP that map to our main PHP images.

The README has been updated with instructions on how to run specific images and how to run & connect the Xdebug variants.

There is also a `build.sh` file for automatically generating the Dockerfiles. This has a listing of which PHP image should map to the relevant PHPUnit version and will generate the Dockerfiles appropriately.